### PR TITLE
feat(getParentRolesSet): return a copy for safety's sake, and add getRoleAndParentRolesSet method

### DIFF
--- a/src/RolesCalc.js
+++ b/src/RolesCalc.js
@@ -59,7 +59,7 @@ export default class RolesCalc {
     }
 
     // Look up a flattened set of roles that extend the required role
-    const parentRoles: Set<string> = this.getParentRolesSet(required)
+    const parentRoles: Set<string> = this._getParentRolesSet(required)
     for (let actualRole of actualArr) {
       if (actualRole === required)
         return true
@@ -97,13 +97,23 @@ export default class RolesCalc {
     return pruned
   }
 
-  getParentRolesSet(role: string): Set<string> {
+  _getParentRolesSet(role: string): Set<string> {
     let parentRoles: ?Set<string> = this._childRolesToParentRolesFlattened.get(role)
     if (!parentRoles) {
       parentRoles = this._calcParentRolesSet(role)
       this._childRolesToParentRolesFlattened.set(role, parentRoles)
     }
     return parentRoles
+  }
+
+  getParentRolesSet(role: string): Set<string> {
+    return new Set(this._getParentRolesSet(role))
+  }
+
+  getRoleAndParentRolesSet(role: string): Set<string> {
+    const result = this.getParentRolesSet(role)
+    result.add(role)
+    return result
   }
 
   _calcParentRolesSet(role: string): Set<string> {

--- a/test/index.js
+++ b/test/index.js
@@ -219,4 +219,17 @@ describe('RolesCalc', () => {
       }
     })
   })
+
+  describe('getParentRolesSet', () => {
+    it('always returns a new set', () => {
+      const rc = new RolesCalc({alwaysAllow: ['admin']})
+      expect(rc.getParentRolesSet('foo')).not.to.equal(rc.getParentRolesSet('foo'))
+    })
+  })
+  describe('getRoleAndParentRolesSet', () => {
+    it('includes the queried role', () => {
+      const rc = new RolesCalc({alwaysAllow: ['admin']})
+      expect(rc.getRoleAndParentRolesSet('foo').has('foo')).to.be.true
+    })
+  })
 })


### PR DESCRIPTION
I didn't realize when I made `_getParentRolesSet` public, I've gotta make it return a copy lest the caller make changes to the returned set and break everything.